### PR TITLE
Chef repo cleanup after build

### DIFF
--- a/configure
+++ b/configure
@@ -76,4 +76,4 @@ echo "$( date "+%Y-%m-%d %H:%M:%S"):  $(git rev-parse --short HEAD)" >> "../CHEF
 popd 
 
 # Remove chef repository after configuration
-sudo rm -r chef_repo
+rm -r -f chef_repo

--- a/configure
+++ b/configure
@@ -72,7 +72,7 @@ wd="$(pwd)"
 cinc-solo -c "${wd}/.chef/solo.rb" -E "$CHEF_ENVIRONMENT" -j "${wd}/${CHEF_SOLO_FILE}"
 
 # Write date + commit SHA to a changelog
-echo "$( date "+%Y-%m-%d %H:%M:%S"):  $(git rev-parse --short HEAD)" >> "../CHEF_CHANGELOG.txt"; 
+echo "$( date "+%Y-%m-%d %H:%M:%S"):  $(git rev-parse --short HEAD)" >> "../CHEF_COMMITLOG.txt"; 
 popd 
 
 # Remove chef repository after configuration

--- a/configure
+++ b/configure
@@ -67,6 +67,13 @@ save_configuration
 
 freshen_chef_repo
 
-cd chef_repo
+pushd chef_repo
 wd="$(pwd)"
-exec cinc-solo -c "${wd}/.chef/solo.rb" -E "$CHEF_ENVIRONMENT" -j "${wd}/${CHEF_SOLO_FILE}"
+cinc-solo -c "${wd}/.chef/solo.rb" -E "$CHEF_ENVIRONMENT" -j "${wd}/${CHEF_SOLO_FILE}"
+
+# Write date + commit SHA to a changelog
+echo "$( date "+%Y-%m-%d %H:%M:%S"):  $(git rev-parse --short HEAD)" >> "../CHEF_CHANGELOG.txt"; 
+popd 
+
+# Remove chef repository after configuration
+sudo rm -r chef_repo


### PR DESCRIPTION
## :new: Chef repo cleanup after agent configuration

This PR adds the cleanup for the chef repo folder on the agent. This closes  #6

## Testing
### Strategy
- Add a checkout to this branch on bootstrap.bash in packer repo.
- Add a breakpoint provisioner to an AMI
- SSH into instance to test outcome.
### Tests
- [x]  Repo folder is cleaned after `configure` execution.
<details>

``` bash
~/#: ls
docker-disk-cleanup.sh  ros-buildfarm-deployment  snap
~/# cd ros-buildfarm-deployment/
~/ros-buildfarm-deployment# ls
CHEF_CHANGELOG.txt  bootstrap           configuration.bash.example
README.md           configuration.bash  configure

```
</details>

- [x] Changelog is created with a `date: SHA` information to track chef current config
<details>

```bash
~# cat  CHEF_CHANGELOG.txt 
2023-07-05 17:18:22:  0698b0c
```

</details>

- [x] Agents are built correctly (a.k.a. ran a packer build checking out to this branch with a break point after provisioning successfully) 