### PR TITLE
Support for NO_MAGE option for deployments without encryption

### DIFF
--- a/configure
+++ b/configure
@@ -79,6 +79,8 @@ wd="$(pwd)"
 
 if test -n "$CHEF_MAGE_PROFILE" && test -n "$MAGE_KEY" ; then
 	decrypt_secrets
+elif test -n "$NO_MAGE" ; then
+	echo "NO_MAGE variable is set. No decryption is performed"
 else
 	echo "CHEF_MAGE_PROFILE or MAGE_KEY is not set, and are necessary to perform decryption."
 	exit 1


### PR DESCRIPTION
In the case that we need to perform a deployment without any encryption, we need a way to bypass the check for MAGE setup. I added a NO_MAGE option to do this.
