### PR TITLE
Fix behavior regression when no decryption needed

### DIFF
--- a/configure
+++ b/configure
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
-
+MAGE_KEY=
 set -o errexit -o pipefail -o nounset
 
 # Source configuration file

--- a/configure
+++ b/configure
@@ -77,14 +77,15 @@ freshen_chef_repo
 pushd chef_repo
 wd="$(pwd)"
 
+if (test -n "$CHEF_MAGE_PROFILE" && test -z "$MAGE_KEY") || (test -z "$CHEF_MAGE_PROFILE" && test -n "$MAGE_KEY") ; then 
+		echo "CHEF_MAGE_PROFILE or MAGE_KEY is not set, and are necessary to perform decryption."
+		exit 1
+fi
+
 if test -n "$CHEF_MAGE_PROFILE" && test -n "$MAGE_KEY" ; then
 	decrypt_secrets
-elif test -n "$NO_MAGE" ; then
-	echo "NO_MAGE variable is set. No decryption is performed"
-else
-	echo "CHEF_MAGE_PROFILE or MAGE_KEY is not set, and are necessary to perform decryption."
-	exit 1
 fi
+
 
 cinc-solo -c "${wd}/.chef/solo.rb" -E "$CHEF_ENVIRONMENT" -j "${wd}/${CHEF_SOLO_FILE}"
 

--- a/configure
+++ b/configure
@@ -1,6 +1,5 @@
 #!/usr/bin/bash
-MAGE_KEY=
-set -o errexit -o pipefail -o nounset
+set -o errexit -o pipefail
 
 # Source configuration file
 config_file="$(dirname "${BASH_SOURCE[0]}")/configuration.bash"

--- a/configure
+++ b/configure
@@ -76,7 +76,7 @@ freshen_chef_repo
 pushd chef_repo
 wd="$(pwd)"
 
-if test \( -n "$CHEF_MAGE_PROFILE" -a test -z "$MAGE_KEY" \) -o \( test -z "$CHEF_MAGE_PROFILE" -a test -n "$MAGE_KEY" \); then 
+if test \( -n "$CHEF_MAGE_PROFILE" -a -z "$MAGE_KEY" \) -o \( -z "$CHEF_MAGE_PROFILE" -a -n "$MAGE_KEY" \); then 
 		echo "CHEF_MAGE_PROFILE or MAGE_KEY is not set, and are necessary to perform decryption."
 		exit 1
 fi

--- a/configure
+++ b/configure
@@ -77,7 +77,7 @@ freshen_chef_repo
 pushd chef_repo
 wd="$(pwd)"
 
-if (test -n "$CHEF_MAGE_PROFILE" && test -z "$MAGE_KEY") || (test -z "$CHEF_MAGE_PROFILE" && test -n "$MAGE_KEY") ; then 
+if test \( -n "$CHEF_MAGE_PROFILE" -a test -z "$MAGE_KEY" \) -o \( test -z "$CHEF_MAGE_PROFILE" -a test -n "$MAGE_KEY" \); then 
 		echo "CHEF_MAGE_PROFILE or MAGE_KEY is not set, and are necessary to perform decryption."
 		exit 1
 fi


### PR DESCRIPTION
By adding the integration to Mage tool for decryption a behavior regression was introduced where it would fail if no MAGE related variables where configured. 
This was first addressed by @j-rivero on #11 by adding a flag to bypass this. 
This PR removes that option and restores the behavior to be: 
- If no MAGE related ENV variable is present, then  keep execution as normal.
- If MAGE variables are present, then verifies validity of setup and decrypts. 
