### PR TITLE
Pass why-run flag to configure script

### DIFF
--- a/configure
+++ b/configure
@@ -13,9 +13,10 @@ fi
 
 usage() {
 	cat <<EOF
-$0 [CHEF_REPO CHEF_ENVIRONMENT CHEF_SOLO_FILE]
+$0 [-W|--why-run] [CHEF_REPO CHEF_ENVIRONMENT CHEF_SOLO_FILE]
 	Configure the current host using chef-solo.
 
+  -W|--why-run Run cinc-solo in why-run mode (dry run).
 	CHEF_REPO the url of the chef configuration repository.
 	CHEF_ENVIRONMENT the chef environment for this host.
 	CHEF_SOLO_FILE the node template for this host, relative to the CHEF_REPO root.
@@ -56,6 +57,25 @@ decrypt_secrets() {
 	MAGE_KEY=$MAGE_KEY "${mage}/mage.sh" -c "${mage}/mage.yml" -P "$CHEF_MAGE_PROFILE" -d
 } 
 
+WHY_RUN_FLAG=""
+POSITIONAL_ARGS=()
+
+# Parse flags
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -W|--why-run)
+      WHY_RUN_FLAG="--why-run"
+      shift
+      ;;
+    *)
+      POSITIONAL_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+set -- "${POSITIONAL_ARGS[@]}"
+
 # Fresh CLI args will override configured values
 CHEF_REPO="${1:-$CHEF_REPO}"
 CHEF_BRANCH="${2:-$CHEF_BRANCH}"
@@ -88,7 +108,7 @@ if test -n "$CHEF_MAGE_PROFILE" && test -n "$MAGE_KEY" ; then
 fi
 
 
-cinc-solo -c "${wd}/.chef/solo.rb" -E "$CHEF_ENVIRONMENT" -j "${wd}/${CHEF_SOLO_FILE}"
+cinc-solo $WHY_RUN_FLAG -c "${wd}/.chef/solo.rb" -E "$CHEF_ENVIRONMENT" -j "${wd}/${CHEF_SOLO_FILE}"
 
 # Write date + commit SHA to a changelog
 echo "$( date "+%Y-%m-%d %H:%M:%S"):  $(git rev-parse --short HEAD)" >> "../CHEF_COMMITLOG.txt"; 

--- a/configure
+++ b/configure
@@ -16,7 +16,7 @@ usage() {
 $0 [-W|--why-run] [CHEF_REPO CHEF_ENVIRONMENT CHEF_SOLO_FILE]
 	Configure the current host using chef-solo.
 
-  -W|--why-run Run cinc-solo in why-run mode (dry run).
+	-W|--why-run Run cinc-solo in why-run mode (dry run).
 	CHEF_REPO the url of the chef configuration repository.
 	CHEF_ENVIRONMENT the chef environment for this host.
 	CHEF_SOLO_FILE the node template for this host, relative to the CHEF_REPO root.


### PR DESCRIPTION
# Description

This flag is needed to pass `-W|--why-run` (dry run) to the `cinc-solo` command. This allows running configure without deploy for testing before deploying purposes.


Run example:
```
ubuntu@ip-10-0-1-20:~/ros-buildfarm-deployment$ sudo -E ./configure -W
~/ros-buildfarm-deployment/chef_repo ~/ros-buildfarm-deployment
HEAD is now at ...
~/ros-buildfarm-deployment
~/ros-buildfarm-deployment/chef_repo ~/ros-buildfarm-deployment
Running: /opt/cinc/embedded/bin/ruby /home/ubuntu/ros-buildfarm-deployment/chef_repo/mage/mage.rb -c /home/ubuntu/ros-buildfarm-deployment/chef_repo/mage/mage.yml -P staging-jenkins -d
/home/ubuntu/ros-buildfarm-deployment/chef_repo/.chef/solo.rb:1: warning: already initialized constant Class::REPO_DIR
/home/ubuntu/ros-buildfarm-deployment/chef_repo/.chef/solo.rb:1: warning: previous definition of REPO_DIR was here
Cinc Client, version 17.10.165
Patents: https://www.chef.io/patents
Infra Phase starting
Resolving cookbooks for run list: ["ros_buildfarm::jenkins"]
Synchronizing cookbooks:
  - jenkins (0.1.0)
  - ros_buildfarm (0.5.1)
Installing cookbook gem dependencies:

...


  * execute[python3 -m pip uninstall -y pulp-rpm-client] action run (skipped due to only_if)
  * execute[python3 -m pip uninstall -y pulpcore-client] action run (skipped due to only_if)
  * apt_package[qemu-user-static] action install (up to date)
  * template[/etc/default/jenkins-agent] action create (up to date)
  * directory[/etc/jenkins-agent] action create (up to date)
  * file[/etc/jenkins-agent/token] action create (up to date)
  * ruby_block[needrestart-config] action run
    - Would execute the ruby block needrestart-config
  * template[/etc/systemd/system/jenkins-agent.service] action create (up to date)
  * execute[systemctl-daemon-reload] action nothing (skipped due to action :nothing)
  * service[jenkins-agent] action start
    * Service status not available. Assuming a prior action would have installed the service.
    * Assuming status of not running.
     (up to date)
  * service[jenkins-agent] action enable
    * Service status not available. Assuming a prior action would have installed the service.
    * Assuming status of not running.
     (up to date)
Recipe: ros_buildfarm::jenkins
  * group[docker] action manage (up to date)
  * service[jenkins] action restart
    * Service status not available. Assuming a prior action would have installed the service.
    * Assuming status of not running.
    - Would restart service service[jenkins]
  * template[update ssh known hosts file /etc/ssh/ssh_known_hosts] action create (up to date)
[2026-03-31T08:44:46-07:00] WARN: In why-run mode, so NOT performing node save.

Running handlers:
Running handlers complete
Infra Phase complete, 9/104 resources would have been updated
~/ros-buildfarm-deployment
```

Note the comments: `Would restart service service[jenkins]` as the verification that `--why-run` is passed through `cinc-solo`
	
